### PR TITLE
Added correct link to online visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ In addition, the BAL framework defines a few interfaces:
   context factories
 
 The full documentation for the API is available on 
- [github.io](https://ballon-rouge.github.io/bal/)
+ [github.io](https://redballoonsecurity.github.io/bal-visualizer/)
 
 
 


### PR DESCRIPTION
Changed link from https://ballon-rouge.github.io/bal/ to https://redballoonsecurity.github.io/bal-visualizer/